### PR TITLE
Se elimina declaración de fuentes para svg

### DIFF
--- a/core/mixins/preconfig-mixins/_ultraligero-legacy-mixins.scss
+++ b/core/mixins/preconfig-mixins/_ultraligero-legacy-mixins.scss
@@ -43,7 +43,6 @@
     	src: url('#{$font-filename}.eot?#iefix') format('embedded-opentype');
 		src: url('#{$font-filename}.woff') format('woff');
         src: url('#{$font-filename}.ttf') format('truetype');
-        src: url('#{$font-filename}.svg##{$font-filename}') format('svg');
 		font-weight: $font-weight;
 		font-style: $font-style;
 		font-stretch: $font-stretch;


### PR DESCRIPTION
En exploradores anteriores las fuentes no se muestran correctamente, ya que las fuentes en SVG no se muestran correctamente, se elimina declaración para SVG.